### PR TITLE
feat: peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,15 @@
     "eslint-plugin-unicorn": "^19.0.1",
     "prettier": "^2.0.5"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "peerDependencies": {
+    "eslint-plugin-jest": "23.x",
+    "eslint-plugin-no-loops": "^0.3.0",
+    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-promise": "4.x",
+    "eslint-plugin-security": "1.x",
+    "eslint-plugin-sonarjs": "^0.5.0",
+    "eslint-plugin-toplevel": "1.x",
+    "eslint-plugin-unicorn": "19.x"
+  }
 }


### PR DESCRIPTION
- analog https://www.npmjs.com/package/eslint-config-airbnb-base
- damit sollte `npx install-peerdeps --dev eslint-config-heise` gehen